### PR TITLE
feat: conditionally create ecs resource with different lifecycle policy

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -381,14 +381,8 @@ variable "task_role_arn" {
   type        = string
 }
 
-variable "ignore_all_changes" {
-  default     = false
-  description = "Ignore all changes to the ecs service."
-  type        = bool
-}
-
 variable "prevent_destroy" {
   default     = false
-  description = "Prevent the service from being destroyed."
+  description = "Prevent the ECS service from being destroyed."
   type        = bool
 }


### PR DESCRIPTION
Terraform doesn't allow [dynamic expressions](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#literal-values-only). Currently, the design pattern that is being used to circumvent this is to add 2 identical resources (except the lifecycle policy) and conditionally create one of them.  